### PR TITLE
🧹 Remove commented-out learning rate schedule

### DIFF
--- a/src/gensbi/recipes/pipeline.py
+++ b/src/gensbi/recipes/pipeline.py
@@ -345,13 +345,6 @@ class AbstractPipeline(abc.ABC):
         nsteps = self.training_config["nsteps"]
         max_lr = self.training_config["max_lr"]
         min_lr = self.training_config["min_lr"]
-        # schedule = optax.warmup_cosine_decay_schedule(
-        #     init_value=1e-7,  # Start tiny
-        #     peak_value=max_lr,  # Peak
-        #     warmup_steps=warmup_steps,
-        #     decay_steps=nsteps - warmup_steps,
-        #     end_value=min_lr,  # 1% of Peak
-        # )
 
         # we define the following schedule using join schedules: warmup for warmup_steps, then constant LR until 90% of the training steps, then cosine decay to min_lr
         decay_transition = self.training_config["decay_transition"]


### PR DESCRIPTION
🎯 **What:** Removed commented-out `optax.warmup_cosine_decay_schedule` block from `src/gensbi/recipes/pipeline.py`.
💡 **Why:** The commented-out code was dead code and redundant, as the active implementation uses `optax.join_schedules`. Removing it improves code readability and maintainability.
✅ **Verification:** Verified that the changes do not affect the functionality by running `test/recipes/test_pipelines_general.py` which passed successfully. The removal is purely cosmetic.
✨ **Result:** Cleaner and more readable code in `src/gensbi/recipes/pipeline.py`.

---
*PR created automatically by Jules for task [3868725773598116670](https://jules.google.com/task/3868725773598116670) started by @aurelio-amerio*