### PR TITLE
🔒 Fix security vulnerability: Replace assert with runtime check in Flux1 recipes

### DIFF
--- a/src/gensbi/recipes/flux1.py
+++ b/src/gensbi/recipes/flux1.py
@@ -110,7 +110,8 @@ def _flux1_config_from_path(config_path: str, dim_obs: int, dim_cond: int):
     method = strategy.get("method")
     model_type = strategy.get("model")
 
-    assert model_type == "flux", f"Model type {model_type} not supported."
+    if model_type != "flux":
+        raise ValueError(f"Model type {model_type} not supported.")
 
     params_dict = parse_flux1_params(config_path)
 
@@ -299,7 +300,8 @@ class Flux1FlowPipeline(ConditionalFlowPipeline):
             config_path, dim_obs, dim_cond
         )
 
-        assert method == "flow", f"Method {method} not supported in Flux1FlowPipeline."
+        if method != "flow":
+            raise ValueError(f"Method {method} not supported in Flux1FlowPipeline.")
 
         # add checkpoint dir to training config
         training_config["checkpoint_dir"] = checkpoint_dir
@@ -439,9 +441,10 @@ class Flux1DiffusionPipeline(ConditionalDiffusionPipeline):
             config_path, dim_obs, dim_cond
         )
 
-        assert (
-            method == "diffusion"
-        ), f"Method {method} not supported in Flux1DiffusionPipeline."
+        if method != "diffusion":
+            raise ValueError(
+                f"Method {method} not supported in Flux1DiffusionPipeline."
+            )
 
         # add checkpoint dir to training config
         training_config["checkpoint_dir"] = checkpoint_dir


### PR DESCRIPTION
🔒 **Security Fix: Production Assertion in Flux1 Configuration**

**What:**
Replaced `assert` statements with explicit `if ...: raise ValueError(...)` checks in `src/gensbi/recipes/flux1.py`.

**Risk:**
The previous implementation used `assert` to validate the model type and pipeline method from the configuration file. When Python is run with the `-O` (optimize) flag, these assertions are stripped out. This could allow a user to initialize a pipeline with an invalid or unsupported configuration without an immediate error, potentially leading to undefined behavior or silent failures later in execution.

**Solution:**
Replaced the assertions with standard runtime checks that raise `ValueError`. This guarantees that invalid configurations are always caught, regardless of the optimization level used when running the code.

**Changes:**
- `src/gensbi/recipes/flux1.py`:
    - In `_flux1_config_from_path`: Replaced `assert model_type == "flux"` with `ValueError`.
    - In `Flux1FlowPipeline.init_pipeline_from_config`: Replaced `assert method == "flow"` with `ValueError`.
    - In `Flux1DiffusionPipeline.init_pipeline_from_config`: Replaced `assert method == "diffusion"` with `ValueError`.

**Verification:**
- Verified using custom reproduction scripts (`reproduce_issue.py` and `reproduce_method_check.py`) that invalid configurations now raise `ValueError` both with and without the `-O` flag.
- Ran existing relevant tests (`test/recipes/test_pipelines_models.py` and `test/recipes/test_pipelines_general.py`) to ensure no regressions. All passed.

---
*PR created automatically by Jules for task [9467144963066046273](https://jules.google.com/task/9467144963066046273) started by @aurelio-amerio*